### PR TITLE
GithubのsignInをtry, catch内で処理しない

### DIFF
--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -7,7 +7,6 @@ export const isErrorCode = (code: unknown): code is ErrorCode => {
 export const ErrorCode = {
   INCORRECT_EMAIL_PASSWORD: 'INCORRECT_EMAIL_PASSWORD',
   FAILED_UNIQUE_CONSTRAINT_EMAIL: 'FAILED_UNIQUE_CONSTRAINT_EMAIL',
-  GITHUB_AUTH_ERROR: 'GITHUB_AUTH_ERROR',
   INTERNAL_SEVER_ERROR: 'INTERNAL_SEVER_ERROR',
 } as const;
 
@@ -16,6 +15,5 @@ export const ERROR_MESSAGES: Record<keyof typeof ErrorCode, string> = {
     'メールアドレスかパスワードが間違っています',
   [ErrorCode.FAILED_UNIQUE_CONSTRAINT_EMAIL]:
     'すでに同じメールアドレスが使用されています',
-  [ErrorCode.GITHUB_AUTH_ERROR]: '認証エラーが発生しました',
   [ErrorCode.INTERNAL_SEVER_ERROR]: 'システムエラーが発生しました',
 };

--- a/src/features/auth/actions/index.ts
+++ b/src/features/auth/actions/index.ts
@@ -1,14 +1,9 @@
 'use server';
 
-import { ERROR_MESSAGES } from '@/config/errors';
 import { signIn } from '@/lib/next-auth/auth';
 
 export async function githubLogin() {
-  try {
-    await signIn('github', {
-      redirectTo: '/',
-    });
-  } catch {
-    return { messages: [ERROR_MESSAGES.GITHUB_AUTH_ERROR] };
-  }
+  await signIn('github', {
+    redirectTo: '/',
+  });
 }

--- a/src/features/auth/components/github-form.tsx
+++ b/src/features/auth/components/github-form.tsx
@@ -2,7 +2,6 @@
 
 import { useFormState, useFormStatus } from 'react-dom';
 
-import { FieldErrors } from '@/components/form/field';
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
 
@@ -29,12 +28,11 @@ const SubmitButton = ({ type }: GithubFormProps) => {
 };
 
 export const GithubForm = ({ type }: GithubFormProps) => {
-  const [error, action] = useFormState(githubLogin, undefined);
+  const [_, action] = useFormState(githubLogin, undefined);
 
   return (
     <form id="github-login" className="grid gap-4" action={action}>
       <SubmitButton type={type} />
-      {error && <FieldErrors errors={error.messages} />}
     </form>
   );
 };


### PR DESCRIPTION
### issues
- try, catch内で処理するとログインできなくなるため変更