### PR TITLE
docker-composeのversionが非推奨なので削除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     container_name: app


### PR DESCRIPTION
### issues
- コンテナ起動時にwarningが出るため対応
```
WARN[0000] /forwards/docker-compose.yml: `version` is obsolete 
```