### PR TITLE
fix: v10からclassNameが利用できなくなった

### DIFF
--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -4,14 +4,11 @@ import { vscDarkPlus } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
 import { cn } from '@/lib/utils';
 
-type MarkdownProps = {
-  value?: string;
-  className?: string;
-};
+type MarkdownProps = { value?: string; className?: string };
 
 const Markdown = ({ value, className }: MarkdownProps) => {
   return (
-    <ReactMarkdown
+    <div
       className={cn(
         'min-h-[158px] whitespace-pre-wrap text-sm [overflow-wrap:anywhere]',
         'prose prose-sm dark:prose-invert',
@@ -24,29 +21,28 @@ const Markdown = ({ value, className }: MarkdownProps) => {
         'prose-li:m-0',
         className,
       )}
-      components={{
-        code({ node, className, children, ...props }) {
-          const match = /language-(\w+)/.exec(className || '');
-          return match ? (
-            <SyntaxHighlighter
-              style={vscDarkPlus}
-              language={match[1]}
-              customStyle={{
-                margin: 0,
-                padding: 0,
-                background: 'none',
-              }}
-            >
-              {children ? String(children).replace(/\n$/, '') : ''}
-            </SyntaxHighlighter>
-          ) : (
-            <code {...props}>{children}</code>
-          );
-        },
-      }}
     >
-      {value}
-    </ReactMarkdown>
+      <ReactMarkdown
+        components={{
+          code({ node, className, children, ...props }) {
+            const match = /language-(\w+)/.exec(className || '');
+            return match ? (
+              <SyntaxHighlighter
+                style={vscDarkPlus}
+                language={match[1]}
+                customStyle={{ margin: 0, padding: 0, background: 'none' }}
+              >
+                {children ? String(children).replace(/\n$/, '') : ''}
+              </SyntaxHighlighter>
+            ) : (
+              <code {...props}>{children}</code>
+            );
+          },
+        }}
+      >
+        {value}
+      </ReactMarkdown>
+    </div>
   );
 };
 


### PR DESCRIPTION
# 概要

v10から`<Markdown>`コンポーネントで`className`が利用できなくなったので外側の要素でスタイルを定義する。

# 変更内容

<!-- 実装した機能や修正内容のポイントを箇条書きで記載します -->
<!-- 例: 「通知ボタンの追加」「APIのバリデーション追加」 -->

- https://github.com/remarkjs/react-markdown/blob/main/changelog.md#1000---2025-02-20

# 動作確認

<!-- 動作確認を行った手順や条件を記載します -->
<!-- 例: 「TOPページで通知ボタンをクリックし、通知が表示されることを確認」 -->
- 画面上で動作確認
