### PR TITLE
feat: toPoliteJapanese関数を追加し、入力文字列に丁寧な語尾を追加する機能を実装

### DIFF
--- a/src/utils/to-polite-japanese.test.ts
+++ b/src/utils/to-polite-japanese.test.ts
@@ -1,0 +1,59 @@
+import { toPoliteJapanese } from './to-polite-japanese';
+
+describe('toPoliteJapanese', () => {
+  // Mock Math.random to control the random selection
+  const originalMathRandom = Math.random;
+
+  beforeEach(() => {
+    jest.spyOn(Math, 'random');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    Math.random = originalMathRandom;
+  });
+
+  test('入力文字列に丁寧な語尾を追加すること', () => {
+    const result = toPoliteJapanese('これはペン');
+
+    // Check that the result starts with the input string
+    expect(result.startsWith('これはペン')).toBe(true);
+
+    // Check that one of the polite endings was appended
+    const politeEndings = [
+      'です',
+      'ます',
+      'でございます',
+      'だと思います',
+      'でしょう',
+    ];
+    const hasPoliteEnding = politeEndings.some((ending) =>
+      result.endsWith(ending),
+    );
+    expect(hasPoliteEnding).toBe(true);
+  });
+
+  test('空の文字列入力を処理すること', () => {
+    const result = toPoliteJapanese('');
+
+    // Result should just be one of the polite endings
+    const politeEndings = [
+      'です',
+      'ます',
+      'でございます',
+      'だと思います',
+      'でしょう',
+    ];
+    expect(politeEndings).toContain(result);
+  });
+
+  test('ランダム選択に基づいて特定の語尾を使用すること', () => {
+    // Test with first ending
+    Math.random = jest.fn().mockReturnValue(0);
+    expect(toPoliteJapanese('こんにちは')).toBe('こんにちはです');
+
+    // Test with last ending
+    Math.random = jest.fn().mockReturnValue(0.99);
+    expect(toPoliteJapanese('こんにちは')).toBe('こんにちはでしょう');
+  });
+});

--- a/src/utils/to-polite-japanese.ts
+++ b/src/utils/to-polite-japanese.ts
@@ -1,0 +1,12 @@
+export const toPoliteJapanese = (input: string): string => {
+  const politeEndings = [
+    'です',
+    'ます',
+    'でございます',
+    'だと思います',
+    'でしょう',
+  ];
+  const randomEnding =
+    politeEndings[Math.floor(Math.random() * politeEndings.length)];
+  return input + randomEnding;
+};


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# 概要

<!-- このPRで解決する内容を簡潔に記載します -->
<!-- 例: 「通知機能の実装」や「バリデーションロジックの修正」 -->

toPoliteJapanese関数を追加し、入力文字列に丁寧な語尾を追加する機能を実装

# 関連Issue

<!-- 対応しているIssueがあれば箇条書きでリンクします -->
<!-- 例: 「Closes #1」 -->

- Closes #

# 変更内容

<!-- 実装した機能や修正内容のポイントを箇条書きで記載します -->
<!-- 例: 「通知ボタンの追加」「APIのバリデーション追加」 -->

-

# 動作確認

<!-- 動作確認を行った手順や条件を記載します -->
<!-- 例: 「TOPページで通知ボタンをクリックし、通知が表示されることを確認」 -->

# 補足情報

<!-- 特筆すべき内容があれば追加で記載します -->
<!-- 例: 「現時点ではiPhoneのみ対応。Androidは未対応」 -->

<!-- I want to review in Japanese. -->
